### PR TITLE
Adds Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,70 @@
+# versioned base image
 FROM ubuntu:20.04
 
-ARG DEBIAN_FRONTEND=noninteractive
-ENV TZ=America/Seattle
-# install required packages
-RUN apt-get update -y\
-&& apt-get install -y g++ gcc gfortran make autoconf automake libtool\
-&& apt-get install -y zlib1g-dev liblzma-dev libbz2-dev lbzip2 libgsl-dev\
-&& apt-get install -y libblas-dev libx11-dev libboost1.71-all-dev git wget\
-&& apt-get install -y libreadline-dev libxt-dev libpcre2-dev libcurl4-openssl-dev
-# create a directory and extract R and HTSlib
-RUN mkdir Tools && cd Tools\
-&& wget https://cran.r-project.org/src/base/R-4/R-4.0.2.tar.gz\
-&&  wget https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10.2.tar.bz2\
-&& tar -zxvf R-4.0.2.tar.gz && tar -jxvf htslib-1.10.2.tar.bz2
-# compile R standalone math library
-RUN cd Tools/R-4.0.2/ && ./configure\
-&& cd src/nmath/standalone/ && make
-# compile HTSlib
-RUN cd Tools/htslib-1.10.2/ && ./configure && make
-# download QTLtools
-RUN cd Tools && git clone https://github.com/qtltools/qtltools.git
-# update file paths and compile QTLtools
-RUN cd Tools/qtltools\
-&& sed -i "s|BOOST_INC=|BOOST_INC=/usr/include|" Makefile\
-&& sed -i "s|BOOST_LIB=|BOOST_LIB=/usr/lib/x86_64-linux-gnu|" Makefile\
-&& sed -i "s|RMATH_INC=|RMATH_INC=/Tools/R-4.0.2/src/include|" Makefile\
-&& sed -i "s|RMATH_LIB=|RMATH_LIB=/Tools/R-4.0.2/src/nmath/standalone|" Makefile\
-&& sed -i "s|HTSLD_INC=|HTSLD_INC=/Tools/htslib-1.10.2|" Makefile\
-&& sed -i "s|HTSLD_LIB=|HTSLD_LIB=/Tools/htslib-1.10.2|" Makefile\
-&& make
-
-RUN cd Tools/qtltools && make install && exec bash
-
-# copy binary
-RUN cp Tools/qtltools/bin/QTLtools /usr/local/bin/
-
+# -- metadata --
 LABEL maintainer="Kelsey Montgomery <kelsey.montgomery@sagebase.org>"
 LABEL base_image="ubuntu:20.04"
 LABEL about.summary="Docker image for eQTL workflow with QTL tools and CWL"
 LABEL about.license="SPDX:Apache-2.0"
+
+# avoid interactive prompts when installing required packages
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/Seattle
+
+# install required packages
+RUN apt-get update --yes \
+ && apt-get install --yes \
+    g++ \
+    gcc \
+    gfortran \
+    make \
+    autoconf \
+    automake \
+    libtool \
+    zlib1g-dev \
+    liblzma-dev \
+    libbz2-dev \
+    lbzip2 \
+    libgsl-dev \
+    libblas-dev \
+    libx11-dev \
+    libboost1.71-all-dev \
+    git \
+    wget \
+    libreadline-dev \
+    libxt-dev \
+    libpcre2-dev \
+    libcurl4-openssl-dev 
+
+# create a directory and extract R and HTSlib
+WORKDIR Tools
+
+RUN wget https://cran.r-project.org/src/base/R-4/R-4.0.2.tar.gz \
+    https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10.2.tar.bz2 \
+ && tar -zxvf R-4.0.2.tar.gz \
+ && tar -jxvf htslib-1.10.2.tar.bz2
+
+# compile R standalone math library
+RUN cd R-4.0.2/ && ./configure \
+ && cd src/nmath/standalone/ && make
+
+# compile HTSlib
+RUN cd htslib-1.10.2/ && ./configure && make
+
+# download QTLtools
+RUN git clone https://github.com/qtltools/qtltools.git
+
+# update file paths and compile QTLtools
+RUN cd qtltools \
+ && sed -i "s|BOOST_INC=|BOOST_INC=/usr/include|" Makefile \
+ && sed -i "s|BOOST_LIB=|BOOST_LIB=/usr/lib/x86_64-linux-gnu|" Makefile \
+ && sed -i "s|RMATH_INC=|RMATH_INC=/Tools/R-4.0.2/src/include|" Makefile \
+ && sed -i "s|RMATH_LIB=|RMATH_LIB=/Tools/R-4.0.2/src/nmath/standalone|" Makefile \
+ && sed -i "s|HTSLD_INC=|HTSLD_INC=/Tools/htslib-1.10.2|" Makefile \
+ && sed -i "s|HTSLD_LIB=|HTSLD_LIB=/Tools/htslib-1.10.2|" Makefile \
+ && make
+
+RUN cd qtltools && make install && exec bash
+
+# copy binary
+RUN cp qtltools/bin/QTLtools /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN cd R-4.0.2/ && ./configure \
 RUN cd htslib-1.10.2/ && ./configure && make
 
 # download QTLtools
-RUN git clone https://github.com/qtltools/qtltools.git
+RUN git clone https://github.com/qtltools/qtltools/releases/tag/1.3.1
 
 # update file paths and compile QTLtools
 RUN cd qtltools \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -y\
 # create a directory and extract R and HTSlib
 RUN mkdir Tools && cd Tools\
 && wget https://cran.r-project.org/src/base/R-4/R-4.0.2.tar.gz\
-&& wget https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10.2.$
+&&  wget https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10.2.tar.bz2\
 && tar -zxvf R-4.0.2.tar.gz && tar -jxvf htslib-1.10.2.tar.bz2
 # compile R standalone math library
 RUN cd Tools/R-4.0.2/ && ./configure\

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,16 @@ FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/Seattle
+# install required packages
 RUN apt-get update -y\
 && apt-get install -y g++ gcc gfortran make autoconf automake libtool\
 && apt-get install -y zlib1g-dev liblzma-dev libbz2-dev lbzip2 libgsl-dev\
 && apt-get install -y libblas-dev libx11-dev libboost1.71-all-dev git wget\
-&& apt-get install -y libreadline-dev libxt-dev libpcre2-dev libcurl4-openssl-d$
-
+&& apt-get install -y libreadline-dev libxt-dev libpcre2-dev libcurl4-openssl-dev
+# create a directory and extract R and HTSlib
 RUN mkdir Tools && cd Tools\
 && wget https://cran.r-project.org/src/base/R-4/R-4.0.2.tar.gz\
-&& wget https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10$
+&& wget https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10.2.$
 && tar -zxvf R-4.0.2.tar.gz && tar -jxvf htslib-1.10.2.tar.bz2
 # compile R standalone math library
 RUN cd Tools/R-4.0.2/ && ./configure\
@@ -19,20 +20,20 @@ RUN cd Tools/R-4.0.2/ && ./configure\
 RUN cd Tools/htslib-1.10.2/ && ./configure && make
 # download QTLtools
 RUN cd Tools && git clone https://github.com/qtltools/qtltools.git
-# update file paths and make
+# update file paths and compile QTLtools
 RUN cd Tools/qtltools\
-&& BOOST_INC=/usr/include\
-&& BOOST_LIB=/usr/lib/x86_64-linux-gnu\
-&& RMATH_INC=${HOME}/Tools/R-4.0.2/src/include\
-&& RMATH_LIB=${HOME}/Tools/R-4.0.2/src/nmath/standalone\
-&& HTSLD_INC=${HOME}/Tools/htslib-1.10.2\
-&& HTSLD_LIB=${HOME}/Tools/htslib-1.10.2
-# append to path
-ENV PATH=${PATH}:./bin/:./scripts/
-ENV MANPATH=${MANPATH}:./man/
-ENV PATH=${PATH}:././Tools/doc/QTLtools_bash_autocomplete.bash
-# compile QTLtools
-RUN cd Tools/qtltools && make
+&& sed -i "s|BOOST_INC=|BOOST_INC=/usr/include|" Makefile\
+&& sed -i "s|BOOST_LIB=|BOOST_LIB=/usr/lib/x86_64-linux-gnu|" Makefile\
+&& sed -i "s|RMATH_INC=|RMATH_INC=/Tools/R-4.0.2/src/include|" Makefile\
+&& sed -i "s|RMATH_LIB=|RMATH_LIB=/Tools/R-4.0.2/src/nmath/standalone|" Makefile\
+&& sed -i "s|HTSLD_INC=|HTSLD_INC=/Tools/htslib-1.10.2|" Makefile\
+&& sed -i "s|HTSLD_LIB=|HTSLD_LIB=/Tools/htslib-1.10.2|" Makefile\
+&& make
+
+RUN cd Tools/qtltools && make install && exec bash
+
+# copy binary
+RUN cp Tools/qtltools/bin/QTLtools /usr/local/bin/
 
 LABEL maintainer="Kelsey Montgomery <kelsey.montgomery@sagebase.org>"
 LABEL base_image="ubuntu:20.04"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,40 @@
-FROM ubuntu:latest
+FROM ubuntu:20.04
 
-LABEL maintainer="Tess Thyer <tess.thyer@sagebase.org>"
-LABEL base_image="ubuntu:latest"
-LABEL about.summary="Docker image for template dockstore tool"
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/Seattle
+RUN apt-get update -y\
+&& apt-get install -y g++ gcc gfortran make autoconf automake libtool\
+&& apt-get install -y zlib1g-dev liblzma-dev libbz2-dev lbzip2 libgsl-dev\
+&& apt-get install -y libblas-dev libx11-dev libboost1.71-all-dev git wget\
+&& apt-get install -y libreadline-dev libxt-dev libpcre2-dev libcurl4-openssl-d$
+
+RUN mkdir Tools && cd Tools\
+&& wget https://cran.r-project.org/src/base/R-4/R-4.0.2.tar.gz\
+&& wget https://github.com/samtools/htslib/releases/download/1.10.2/htslib-1.10$
+&& tar -zxvf R-4.0.2.tar.gz && tar -jxvf htslib-1.10.2.tar.bz2
+# compile R standalone math library
+RUN cd Tools/R-4.0.2/ && ./configure\
+&& cd src/nmath/standalone/ && make
+# compile HTSlib
+RUN cd Tools/htslib-1.10.2/ && ./configure && make
+# download QTLtools
+RUN cd Tools && git clone https://github.com/qtltools/qtltools.git
+# update file paths and make
+RUN cd Tools/qtltools\
+&& BOOST_INC=/usr/include\
+&& BOOST_LIB=/usr/lib/x86_64-linux-gnu\
+&& RMATH_INC=${HOME}/Tools/R-4.0.2/src/include\
+&& RMATH_LIB=${HOME}/Tools/R-4.0.2/src/nmath/standalone\
+&& HTSLD_INC=${HOME}/Tools/htslib-1.10.2\
+&& HTSLD_LIB=${HOME}/Tools/htslib-1.10.2
+# append to path
+ENV PATH=${PATH}:./bin/:./scripts/
+ENV MANPATH=${MANPATH}:./man/
+ENV PATH=${PATH}:././Tools/doc/QTLtools_bash_autocomplete.bash
+# compile QTLtools
+RUN cd Tools/qtltools && make
+
+LABEL maintainer="Kelsey Montgomery <kelsey.montgomery@sagebase.org>"
+LABEL base_image="ubuntu:20.04"
+LABEL about.summary="Docker image for eQTL workflow with QTL tools and CWL"
 LABEL about.license="SPDX:Apache-2.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN cd R-4.0.2/ && ./configure \
 RUN cd htslib-1.10.2/ && ./configure && make
 
 # download QTLtools
-RUN git clone https://github.com/qtltools/qtltools/releases/tag/1.3.1
+RUN git clone -b 1.3.1 https://github.com/qtltools/qtltools
 
 # update file paths and compile QTLtools
 RUN cd qtltools \


### PR DESCRIPTION
The final `make` step with QTLtools fails. I think there might be a bug in the compilation. The steps were pulled directly from the compilation examples in Ubuntu 20.04.1 https://qtltools.github.io/qtltools/. 

I confirmed the tool can be installed on MacOS.